### PR TITLE
change to use babel-loader

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = {
       {
         test: /\.js$/,
         exclude: /(node_modules|bower_components)/,
-        loader: 'babel', // 'babel-loader' is also a legal name to reference
+        loader: 'babel-loader', // It seems that we need to use babel-loader 
       },
       {
         test: /\.css$/,


### PR DESCRIPTION
when i build this project got the error below 
according to webpack's doc i changed the babel to babel-loader

ERROR in multi ./src/client/index.js
Module not found: Error: Can't resolve 'babel' in '/Users/lizhuohuang/Workspaces/swip'
BREAKING CHANGE: It's no longer allowed to omit the '-loader' suffix when using loaders.

https://webpack.js.org/guides/migrating/#automatic-loader-module-name-extension-removed
